### PR TITLE
Fix instance_data lookups to use symbols

### DIFF
--- a/lib/blimpy/boxes/aws.rb
+++ b/lib/blimpy/boxes/aws.rb
@@ -9,7 +9,7 @@ module Blimpy::Boxes
     DEFAULT_IMAGE_ID = 'ami-ec0b86dc'
 
     def self.fog_server_for_instance(id, blimpdata)
-      region = blimpdata['region'] || DEFAULT_REGION
+      region = blimpdata[:region] || DEFAULT_REGION
       fog = Fog::Compute.new(:provider => 'AWS', :region => region)
       fog.servers.get(id)
     end

--- a/lib/blimpy/fleet.rb
+++ b/lib/blimpy/fleet.rb
@@ -56,7 +56,7 @@ module Blimpy
       boxes = []
       print '>> Resuming: '
       instances.each do |instance_id, instance_data|
-        print "#{instance_data['name']},"
+        print "#{instance_data[:name]},"
         box = Blimpy::Box.from_instance_id(instance_id, instance_data)
         box.resume
         boxes << box
@@ -148,7 +148,7 @@ module Blimpy
 
       members.each do |instance_id, instance_data|
         box = Blimpy::Box.from_instance_id(instance_id, instance_data)
-        print "#{instance_data['name']},"
+        print "#{instance_data[:name]},"
         box.stop
         boxes << box
       end


### PR DESCRIPTION
Without this change, `stop` and `destroy` will both fail.
