### PR TITLE
Fix bug causing inconsistent values for security group names

### DIFF
--- a/lib/blimpy/securitygroups.rb
+++ b/lib/blimpy/securitygroups.rb
@@ -7,15 +7,16 @@ module Blimpy
       if ports.nil? or ports.empty?
         return nil
       end
+      unless ports.is_a? Set
+        ports = Set.new(ports)
+      end
 
-      ports = Set.new(ports)
       # Lolwut, #hash is inconsistent between ruby processes
       "Blimpy-#{Zlib.crc32(ports.inspect)}"
     end
 
     def self.ensure_group(fog, ports)
       name = group_id(ports)
-      ports = Set.new(ports)
 
       exists = fog.security_groups.get(name)
 

--- a/spec/blimpy/securitygroups_spec.rb
+++ b/spec/blimpy/securitygroups_spec.rb
@@ -3,7 +3,7 @@ require 'blimpy/securitygroups'
 
 describe Blimpy::SecurityGroups do
     let(:fog) { mock('Fog object') }
-    let(:ports) { [22, 8080] }
+    let(:ports) { Set.new([22, 8080]) }
 
   describe '#group_id' do
     it 'should return nil for an empty port Array' do


### PR DESCRIPTION
Prior to this commit, there were cases where SecurityGroups#group_id
was called and passed an array of ports and would calculate a name
based on them, and then immediately call it again with a Set of ports.
This would result in the group_id appearing to change in between the
time that we checked to see if a group exists and the time that
we attempt to create it.

This commit simply tweaks the calls to `Set.new` in such a way as
to ensure that the group name is consistent between the "ensure"
and "create" methods.
