### PR TITLE
Bunch O changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group :development do
   gem 'aruba'
   gem 'tempdir'
   gem 'pry'
-  gem 'debugger'
+  gem 'debugger' unless RUBY_VERSION =~ /1.8.+/
 end

--- a/bin/blimpy
+++ b/bin/blimpy
@@ -17,5 +17,9 @@ rescue LoadError
   require 'blimpy/cli'
 end
 
+# allow monkey-patching of Blimpy by the project (mainly to add more commands)
+blimprc = File.join(Dir.pwd,"Blimprc")
+Blimpy.load_file File.open(blimprc).read if File.exists? blimprc
+
 Blimpy::CLI.start
 exit 0

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -229,21 +229,23 @@ module Blimpy
       @exec_commands = false
 
       $stdout.sync = true
+      need_nl = false
 
       until @ssh_connected
         # Run the `true` command and exit
         @ssh_connected = ssh_into('-q', 'true')
         # if SSH is killed (such as Ctrl+C), abort right away
-        raise Blimpy::Exception, "ssh was killed: #{$?.exitstatus}" if $?.exitstatus>128
+        raise Exception, "ssh was killed: #{$?.exitstatus}" if $?.exitstatus>128
 
         unless @ssh_connected
           if (Time.now.to_i - start) < 60
             print '.'
+            need_nl = true
             sleep 1
           end
         end
       end
-      puts
+      puts if need_nl
       @exec_commands = use_exec
     end
 

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -236,6 +236,8 @@ module Blimpy
       until @ssh_connected
         # Run the `true` command and exit
         @ssh_connected = ssh_into('-q', 'true')
+        # if SSH is killed (such as Ctrl+C), abort right away
+        raise Blimpy::Exception, "ssh was killed: #@ssh_connected" if $?.exitstatus>128
 
         unless @ssh_connected
           if (Time.now.to_i - start) < 60

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -13,7 +13,7 @@ module Blimpy
     attr_reader :allowed_regions, :region
     attr_accessor :image_id, :flavor, :group, :ports
     attr_accessor :dns, :internal_dns
-    attr_accessor :name, :tags, :fleet_id, :username, :livery
+    attr_accessor :name, :tags, :fleet_id, :username, :ssh_port, :livery
 
 
     def self.from_instance_id(an_id, data)
@@ -200,6 +200,7 @@ module Blimpy
     def ssh_into(*args)
       run_command('ssh', '-o', 'PasswordAuthentication=no',
                   '-o', 'StrictHostKeyChecking=no',
+                  '-p', ssh_port||22.to_s,
                   '-l', username, dns, *args)
     end
 

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -198,11 +198,6 @@ module Blimpy
     end
 
     def ssh_into(*args)
-      # Support using #ssh_into within our own code as well to pass arguments
-      # to the ssh(1) binary
-      if args.empty?
-        args = ARGV[2 .. -1]
-      end
       run_command('ssh', '-o', 'PasswordAuthentication=no',
                   '-o', 'StrictHostKeyChecking=no',
                   '-l', username, dns, *args)
@@ -233,11 +228,13 @@ module Blimpy
       # after sshd(8) comes online
       @exec_commands = false
 
+      $stdout.sync = true
+
       until @ssh_connected
         # Run the `true` command and exit
         @ssh_connected = ssh_into('-q', 'true')
         # if SSH is killed (such as Ctrl+C), abort right away
-        raise Blimpy::Exception, "ssh was killed: #@ssh_connected" if $?.exitstatus>128
+        raise Blimpy::Exception, "ssh was killed: #{$?.exitstatus}" if $?.exitstatus>128
 
         unless @ssh_connected
           if (Time.now.to_i - start) < 60

--- a/lib/blimpy/cli.rb
+++ b/lib/blimpy/cli.rb
@@ -142,7 +142,7 @@ end
         end
       end
 
-      box.ssh_into
+      box.ssh_into *args
     end
 
     desc 'wait_for_ssh', 'Wait for SSHD to come online'

--- a/lib/blimpy/cli.rb
+++ b/lib/blimpy/cli.rb
@@ -142,8 +142,31 @@ end
         end
       end
 
-      box.wait_for_sshd
       box.ssh_into
+    end
+
+    desc 'wait_for_ssh', 'Wait for SSHD to come online'
+    def wait_for_ssh(name=nil, *args)
+      unless name.nil?
+        box = box_by_name(name)
+        if box.nil?
+          puts "Could not find a blimp named \"#{name}\""
+          exit 1
+        end
+      else
+        blimps = current_blimps
+        unless blimps
+          puts "No Blimps running!"
+          exit 1
+        end
+
+        blimps.each do |blimp, data|
+          next unless data[:name]
+          box = box_by_name(data[:name])
+        end
+      end
+
+      box.wait_for_sshd
     end
 
     desc 'scp BLIMP_NAME FILE_NAME', 'Securely copy FILE_NAME into the blimp'
@@ -154,7 +177,6 @@ end
         puts "Could not find a blimp named \"#{name}\""
         exit 1
       end
-      box.wait_for_sshd
       # Pass any extra commands along to the `scp` invocation
       box.scp_file(filename, '', *ARGV[3..-1])
     end


### PR DESCRIPTION
Four commits that I accumulated over time to use Blimpy for our purposes.

Out of my laziness I'm creating a single pull request for these four commits. If you want to strike down some but willing to take others, please let me know so that I can create a pull request accordingly.
#### Forcing ssh_wait is considered harmful

Various blimpy commands silently wait for SSHD to come online on the remote VM, but if there's any misconfiguration in Blimpfile, this will ends up hanging forever (and users will have no clue why.) I think it's better not to do this out of the box. For interactive use, waiting and rerunning the command is easy, and for a scripted use, I added another command `wait_for_ssh` that does it.
#### ssh_info method using ARGV is harmful

`Box` needs to be usable as a library, so its `ssh_into` method looking at `ARGV` is problematic if I'm writing another command or other ruby code that talks to Blimpy. Leave it to the CLI ssh command to look at ARGV.
#### Blimprc file for defining custom commands

I want to write a pseudo-plugin that extends Blimpy with some project specific commands. For that I allowed `Blimprc` in the project directory that gets loaded into Ruby.
#### Minor output improvements

Got rid of annoing empty line.
