### PR TITLE
Fixed the test regression and then some

### DIFF
--- a/bin/blimpy
+++ b/bin/blimpy
@@ -10,12 +10,8 @@ rescue NameError
   # I don't think we have YAML::ENGINE until Ruby 1.9
 end
 
-begin
-  require 'blimpy/cli'
-rescue LoadError
-  $:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib/')
-  require 'blimpy/cli'
-end
+$:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib/')
+require 'blimpy/cli'
 
 # allow monkey-patching of Blimpy by the project (mainly to add more commands)
 blimprc = File.join(Dir.pwd,"Blimprc")

--- a/features/cli/scp.feature
+++ b/features/cli/scp.feature
@@ -13,7 +13,8 @@ Feature: SCP a file into a named VM
       end
       """
     And I have a file named "hello.txt"
-    When I run `blimpy scp Gherkins hello.txt`
+    When I run `blimpy wait_for_ssh`
+    And I run `blimpy scp Gherkins hello.txt`
     Then the exit status should be 1
     And the output should contain:
       """
@@ -34,5 +35,6 @@ Feature: SCP a file into a named VM
       """
     And I have a file named "hello.txt"
     And I run `blimpy start`
-    When I run `blimpy scp "Cucumber Host" hello.txt`
+    When I run `blimpy wait_for_ssh`
+    And I run `blimpy scp "Cucumber Host" hello.txt`
     Then the exit status should be 0

--- a/features/cli/ssh.feature
+++ b/features/cli/ssh.feature
@@ -12,7 +12,8 @@ Feature: SSH into a named VM
         end
       end
       """
-    When I run `blimpy ssh Gherkins`
+    When I run `blimpy wait_for_ssh`
+    And I run `blimpy ssh Gherkins`
     Then the exit status should be 1
     And the output should contain:
       """

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -34,6 +34,7 @@ end
 
 When /^I ssh into the machine$/ do
   step %{I run `blimpy start`}
+  step %{I run `blimpy wait_for_ssh`}
   step %{I run `blimpy ssh "Cucumber Host" -o StrictHostKeyChecking=no` interactively}
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'aruba/cucumber'
 require 'fileutils'
-require 'ruby-debug'
+require 'ruby-debug' unless RUBY_VERSION =~ /1.8.+/
 require 'temp_dir'
 
 

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -210,6 +210,11 @@ module Blimpy
                   filename, "#{username}@#{dns}:#{directory}", *args)
     end
 
+    def scp_files(directory, files)
+      filename = File.expand_path(filename)
+      run_command(*['scp', '-o', 'StrictHostKeyChecking=no']+files+["#{username}@#{dns}:#{directory}"])
+    end
+
     def bootstrap_livery
       if @livery.kind_of? Symbol
         raise Blimpy::InvalidLiveryException, 'Symbol liveries are unsupported!'

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -241,7 +241,7 @@ module Blimpy
         # Run the `true` command and exit
         @ssh_connected = ssh_into('-q', 'true')
         # if SSH is killed (such as Ctrl+C), abort right away
-        raise Exception, "ssh was killed: #{$?.exitstatus}" if $?.exitstatus>128
+        raise Exception, "ssh was killed: #{$?.exitstatus}" if $?.exitstatus>128 && $?.exitstatus<200
 
         unless @ssh_connected
           if (Time.now.to_i - start) < 60

--- a/lib/blimpy/boxes/aws.rb
+++ b/lib/blimpy/boxes/aws.rb
@@ -1,5 +1,6 @@
 require 'blimpy/box'
 require 'blimpy/boxes'
+require 'fog/aws'
 
 module Blimpy::Boxes
   class AWS < Blimpy::Box

--- a/lib/blimpy/boxes/openstack.rb
+++ b/lib/blimpy/boxes/openstack.rb
@@ -1,5 +1,6 @@
 require 'blimpy/box'
 require 'blimpy/boxes'
+require 'fog/openstack'
 
 module Blimpy::Boxes
   class OpenStack < Blimpy::Box

--- a/lib/blimpy/cli.rb
+++ b/lib/blimpy/cli.rb
@@ -62,6 +62,7 @@ module Blimpy
         fleet = load_blimpfile
       rescue Blimpy::InvalidBlimpFileError => e
         puts "The Blimpfile is invalid!"
+        puts e.to_s
         exit 1
       end
 


### PR DESCRIPTION
A test regression was caused by the lack of "blimpy wait_for_ssh", which was necessary because there's no livery configured for Blimpfiles used in tests.

There are a couple of small changes needed to run tests on Ruby 1.8, and additional error diagnostics in case Blimpfile is incorrect.
