### PR TITLE
Reverting wait_for_ssh command

### DIFF
--- a/features/cli/scp.feature
+++ b/features/cli/scp.feature
@@ -13,8 +13,7 @@ Feature: SCP a file into a named VM
       end
       """
     And I have a file named "hello.txt"
-    When I run `blimpy wait_for_ssh`
-    And I run `blimpy scp Gherkins hello.txt`
+    When I run `blimpy scp Gherkins hello.txt`
     Then the exit status should be 1
     And the output should contain:
       """
@@ -35,6 +34,5 @@ Feature: SCP a file into a named VM
       """
     And I have a file named "hello.txt"
     And I run `blimpy start`
-    When I run `blimpy wait_for_ssh`
-    And I run `blimpy scp "Cucumber Host" hello.txt`
+    When I run `blimpy scp "Cucumber Host" hello.txt`
     Then the exit status should be 0

--- a/features/cli/ssh.feature
+++ b/features/cli/ssh.feature
@@ -12,8 +12,7 @@ Feature: SSH into a named VM
         end
       end
       """
-    When I run `blimpy wait_for_ssh`
-    And I run `blimpy ssh Gherkins`
+    When I run `blimpy ssh Gherkins`
     Then the exit status should be 1
     And the output should contain:
       """

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -34,7 +34,6 @@ end
 
 When /^I ssh into the machine$/ do
   step %{I run `blimpy start`}
-  step %{I run `blimpy wait_for_ssh`}
   step %{I run `blimpy ssh "Cucumber Host" -o StrictHostKeyChecking=no` interactively}
 end
 

--- a/lib/blimpy/cli.rb
+++ b/lib/blimpy/cli.rb
@@ -143,31 +143,8 @@ end
         end
       end
 
-      box.ssh_into *args
-    end
-
-    desc 'wait_for_ssh', 'Wait for SSHD to come online'
-    def wait_for_ssh(name=nil, *args)
-      unless name.nil?
-        box = box_by_name(name)
-        if box.nil?
-          puts "Could not find a blimp named \"#{name}\""
-          exit 1
-        end
-      else
-        blimps = current_blimps
-        unless blimps
-          puts "No Blimps running!"
-          exit 1
-        end
-
-        blimps.each do |blimp, data|
-          next unless data[:name]
-          box = box_by_name(data[:name])
-        end
-      end
-
       box.wait_for_sshd
+      box.ssh_into *args
     end
 
     desc 'scp BLIMP_NAME FILE_NAME', 'Securely copy FILE_NAME into the blimp'
@@ -178,6 +155,7 @@ end
         puts "Could not find a blimp named \"#{name}\""
         exit 1
       end
+      box.wait_for_sshd
       # Pass any extra commands along to the `scp` invocation
       box.scp_file(filename, '', *ARGV[3..-1])
     end


### PR DESCRIPTION
scp and ssh commands now wait for SSH to come online, like they were before.

As we discussed in IRC (and can be seen in the commit message), if the user aborted with Ctrl+C, report what we are doing so that the operator error can be discovered more efficiently.
