### PR TITLE
Use Puppetlabs repo site, not gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Here's an example Blimpfile:
             ship.username = 'ubuntu' # [Optional] SSH username, defaults to "ubuntu" for AWS machines
             ship.flavor = 'm1.small' # [Optional] defaults to t1.micro
             ship.tags = {:mytag => 'somevalue'} # [Optional]
+            ship.provision_on_start = false # [Optional] defaults to true
         end
     end
 ```

--- a/lib/blimpy/box.rb
+++ b/lib/blimpy/box.rb
@@ -14,7 +14,7 @@ module Blimpy
     attr_accessor :image_id, :flavor, :group, :ports
     attr_accessor :dns, :internal_dns
     attr_accessor :name, :tags, :fleet_id, :username, :ssh_port, :livery
-
+    attr_accessor :provision_on_start
 
     def self.from_instance_id(an_id, data)
       return if data[:type].nil?
@@ -33,6 +33,7 @@ module Blimpy
     end
 
     def initialize(server=nil)
+      @provision_on_start = true
       @livery = nil
       @group = nil
       @name = 'Unnamed Box'
@@ -160,7 +161,6 @@ module Blimpy
         state == until_state
       end
     end
-
 
     def with_data(ship_id, data)
       data.each do |key, value|

--- a/lib/blimpy/cli.rb
+++ b/lib/blimpy/cli.rb
@@ -74,6 +74,32 @@ module Blimpy
       fleet.start
     end
 
+    desc 'show', 'Show blimp details for running blimps'
+    method_options :tags => :boolean
+    def show
+      ensure_blimpfile
+      blimps = current_blimps
+      unless blimps
+        puts 'No currently running VMs'
+        exit 0
+      end
+
+      tags_option = options[:tags]
+      blimps.each do |blimp, data|
+        if tags_option
+          tags = nil
+          data[:tags].each do |k,v|
+            if tags.nil?
+              tags = "#{k}=#{v}"
+            elsif
+              tags = "#{tags},#{k}=#{v}"
+            end
+          end
+          puts "#{data[:name]} #{data[:internal_dns]} #{tags}"
+        end
+      end
+    end
+
     desc 'status', 'Show running blimps'
     def status
       ensure_blimpfile

--- a/lib/blimpy/fleet.rb
+++ b/lib/blimpy/fleet.rb
@@ -124,8 +124,10 @@ module Blimpy
         print "\n"
         puts ">> #{host.name} online at: #{host.dns}"
         host.online!
-        host.bootstrap
-        puts
+        if host.provision_on_start
+          host.bootstrap
+          puts
+        end
       end
 
       save!

--- a/scripts/puppet.sh
+++ b/scripts/puppet.sh
@@ -51,12 +51,14 @@ else
     Ubuntu) export PATH=/var/lib/gems/1.8/bin:/usr/local/bin:$PATH
             which puppet > /dev/null 2>&1
             if [ $? -ne 0 ]; then
+              # CODENAME is 'precise', 'oneiric', etc.
+              CODENAME=`lsb_release -c | awk '{print $2}'`
+              REPO_DEB="puppetlabs-release-${CODENAME}.deb"
+              wget --quiet http://apt.puppetlabs.com/${REPO_DEB} || Fatal "Could not retrieve http://apt.puppetlabs.com/${REPO_DEB}"
+              dpkg -i ${REPO_DEB} || Fatal "Could not install Puppet repo source '${REPO_DEB}'"
+              rm -f ${REPO_DEB}
               apt-get update
-              apt-get install -y ruby1.8 \
-                                 ruby1.8-dev \
-                                 libopenssl-ruby1.8 \
-                                 rubygems
-              gem install puppet --version "~> 2.7" --no-ri --no-rdoc
+              apt-get -qqy install puppet-common=2.7.* puppet=2.7.* hiera=1.1.* hiera-puppet=1.0* || Fatal "Could not install Puppet"
             fi
             ;;
     *) Fatal "Unsupported Linux flavor: $LINUXFLAVOR"


### PR DESCRIPTION
Tested with "precise" 12.x ships, should adapt to any Ubuntu
on its own. Targets Puppet 2.7.\* as the gem install used to.
