### PR TITLE
Adds a new box type 'existing'

### DIFF
--- a/lib/blimpy/boxes/existing.rb
+++ b/lib/blimpy/boxes/existing.rb
@@ -4,10 +4,12 @@ require 'fog/core/wait_for'
 require 'etc'
 
 module Blimpy::Boxes
-  # Fake box type for physical computer accessible through SSH
+    # Fake box type for physical computer accessible through SSH
   class Existing < Blimpy::Box
+    attr_accessor :host
+
     def self.fog_server_for_instance(id, blimpdata)
-      ExistingServer.new(id)
+      ExistingServer.new(id,blimpdata[:host])
     end
 
     def initialize(server=nil)
@@ -16,7 +18,7 @@ module Blimpy::Boxes
     end
 
     def validate!
-      if @name.nil?
+      if @host.nil?
         raise Blimpy::BoxValidationError, "Don't know which box to log into --- the host property is not set."
       end
     end
@@ -28,19 +30,20 @@ module Blimpy::Boxes
     private
 
     def create_host
-      ExistingServer.new(@name)
+      ExistingServer.new(@name,@host)
     end
   end
 
   class ExistingServer
-    def initialize(name)
+    def initialize(name,host)
       @name = name
+      @host = host
     end
     def dns_name
-      @name
+      @host
     end
     def private_dns_name
-      @name
+      @host
     end
     def id
       @name

--- a/lib/blimpy/boxes/existing.rb
+++ b/lib/blimpy/boxes/existing.rb
@@ -1,0 +1,61 @@
+require 'ostruct'
+require 'fog/core/timeout'
+require 'fog/core/wait_for'
+require 'etc'
+
+module Blimpy::Boxes
+  # Fake box type for physical computer accessible through SSH
+  class Existing < Blimpy::Box
+    def self.fog_server_for_instance(id, blimpdata)
+      ExistingServer.new(id)
+    end
+
+    def initialize(server=nil)
+      super(server)
+      @username = Etc.getlogin
+    end
+
+    def validate!
+      if @name.nil?
+        raise Blimpy::BoxValidationError, "Don't know which box to log into --- the host property is not set."
+      end
+    end
+
+    def wait_for_state(until_state, &block)
+      # this magical box type becomes any state instantly
+    end
+
+    private
+
+    def create_host
+      ExistingServer.new(@name)
+    end
+  end
+
+  class ExistingServer
+    def initialize(name)
+      @name = name
+    end
+    def dns_name
+      @name
+    end
+    def private_dns_name
+      @name
+    end
+    def id
+      @name
+    end
+
+    def wait_for(timeout=Fog.timeout, interval=1, &block)
+      Fog.wait_for(timeout, interval, &block)
+    end
+
+    # no-ops
+    def stop
+    end
+    def start
+    end
+    def destroy
+    end
+  end
+end

--- a/lib/blimpy/fleet.rb
+++ b/lib/blimpy/fleet.rb
@@ -1,6 +1,7 @@
 require 'blimpy/helpers/state'
 require 'blimpy/boxes/aws'
 require 'blimpy/boxes/openstack'
+require 'blimpy/boxes/existing'
 
 module Blimpy
   class Fleet
@@ -14,8 +15,10 @@ module Blimpy
       @airborn = false
     end
 
+    BOXES = { :aws => Blimpy::Boxes::AWS, :openstack => Blimpy::Boxes::OpenStack, :existing => Blimpy::Boxes::Existing }
+
     def valid_types
-      [:aws, :openstack]
+      BOXES.keys
     end
 
     def add(box_type, &block)
@@ -26,16 +29,12 @@ module Blimpy
         return false
       end
 
-      box = nil
-      if box_type == :aws
-        box = Blimpy::Boxes::AWS.new
-      end
-      if box_type == :openstack
-        box = Blimpy::Boxes::OpenStack.new
-      end
+      box = BOXES[box_type]
 
       if box.nil?
         return false
+      else
+        box = box.new()
       end
       box.fleet_id = @id
       @ships << box


### PR DESCRIPTION
This box type is useful for controlling existing non-cloud machines under blimpy.

We've developed a custom livery that runs chef-solo, and with this box type I could reuse that tooling on physical machines.
